### PR TITLE
Added handling of multiple age inputs from user

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -54,9 +54,12 @@ class Predictor(BasePredictor):
 
         if target_age == "default":
             target_ages = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
-            age_transformers = [AgeTransformer(target_age=age) for age in target_ages]
+        
         else:
-            age_transformers = [AgeTransformer(target_age=target_age)]
+            target_ages = target_age.split(',')
+            target_ages = [int(age) for age in target_ages]
+        
+        age_transformers = [AgeTransformer(target_age=age) for age in target_ages]
 
         results = np.array(aligned_image.resize((1024, 1024)))
         all_imgs = []
@@ -70,7 +73,7 @@ class Predictor(BasePredictor):
                 all_imgs.append(result_image)
                 results = np.concatenate([results, result_image], axis=1)
 
-        if target_age == "default":
+        if target_age == "default" or len(age_transformers) > 1:
             out_path = Path(tempfile.mkdtemp()) / "output.gif"
             imageio.mimwrite(str(out_path), all_imgs, duration=0.3)
         else:


### PR DESCRIPTION
In this pull request, I have made improvements to the age input handling in the Age Progression AI code. The original code had a fixed set of target ages or accepted a single target age as a string. I've expanded the functionality to allow for the processing of multiple age inputs provided as a comma-separated list.

1. Handling Multiple Age Inputs: Instead of only accepting a single target age as a string, the code now accepts a comma-separated list of target ages. For example, you can provide "10,20,30" as the target_age input.

2. Dynamically Generating Age Transformers: With the ability to provide multiple target ages, the code dynamically generates AgeTransformer instances for each specified age. This allows for the processing of multiple age transformations in a single run.

3. Improved Output File Handling: The output file format is now determined based on whether a single age transformation or multiple transformations are requested. If only one transformation is requested, the output is saved as a PNG image. If multiple transformations or the "default" target age set is provided, the output is saved as a GIF animation.

Please review and merge this pull request to benefit from these improvements in age input handling. Thank you!